### PR TITLE
Fix incorrect 'main' entry in package.json, bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "sol-namor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Human readable names for Solana addresses.",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Fixes "Failed to resolve entry for package "sol-namor". The package may have incorrect main/module/exports specified in its package.json."